### PR TITLE
Use the Doctrine fork repo url as a homepage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "doctrine/sql-formatter",
     "description": "a PHP SQL highlighting library",
-    "homepage": "https://github.com/jdorn/sql-formatter/",
+    "homepage": "https://github.com/doctrine/sql-formatter/",
     "keywords": ["sql", "highlight"],
     "license": "MIT",
     "type": "library",


### PR DESCRIPTION
The original repo will just show outdated docs.