### PR TITLE
Remove caching layer

### DIFF
--- a/tests/SqlFormatterTest.php
+++ b/tests/SqlFormatterTest.php
@@ -26,7 +26,7 @@ final class SqlFormatterTest extends TestCase
     private $sqlData;
 
     /** @var Tokenizer */
-    private static $tokenizer;
+    private $tokenizer;
 
     /** @var SqlFormatter */
     private $formatter;
@@ -36,15 +36,15 @@ final class SqlFormatterTest extends TestCase
 
     public static function setUpBeforeClass() : void
     {
-        self::$tokenizer = new Tokenizer();
     }
 
     protected function setUp() : void
     {
         // Force SqlFormatter to run in non-CLI mode for tests
         $this->highlighter = new HtmlHighlighter();
+        $this->tokenizer   = new Tokenizer();
 
-        $this->formatter = new SqlFormatter(self::$tokenizer, $this->highlighter);
+        $this->formatter = new SqlFormatter($this->tokenizer, $this->highlighter);
     }
 
     /**
@@ -96,7 +96,7 @@ final class SqlFormatterTest extends TestCase
      */
     public function testCliHighlight(string $sql, string $html) : void
     {
-        $formatter = new SqlFormatter(self::$tokenizer, new CliHighlighter());
+        $formatter = new SqlFormatter($this->tokenizer, new CliHighlighter());
         $this->assertEquals(trim($html), trim($formatter->format($sql)));
     }
 
@@ -110,22 +110,16 @@ final class SqlFormatterTest extends TestCase
 
     public function testUsePre() : void
     {
-        $formatter = new SqlFormatter(self::$tokenizer, new HtmlHighlighter([], false));
+        $formatter = new SqlFormatter($this->tokenizer, new HtmlHighlighter([], false));
         $actual    = $formatter->highlight('test');
         $expected  = '<span style="color: #333;">test</span>';
         $this->assertEquals($actual, $expected);
 
-        $formatter = new SqlFormatter(self::$tokenizer, new HtmlHighlighter([], true));
+        $formatter = new SqlFormatter($this->tokenizer, new HtmlHighlighter([], true));
         $actual    = $formatter->highlight('test');
         $expected  = '<pre style="color: black; background-color: white;">' .
             '<span style="color: #333;">test</span></pre>';
         $this->assertEquals($actual, $expected);
-    }
-
-    public function testCacheStats() : void
-    {
-        $stats = self::$tokenizer->getCacheStats();
-        $this->assertGreaterThan(1, $stats['hits']);
     }
 
     /**

--- a/tests/performance.php
+++ b/tests/performance.php
@@ -7,11 +7,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use Doctrine\SqlFormatter\SqlFormatter;
 use Doctrine\SqlFormatter\Tokenizer;
 
-$tokenizer = new Tokenizer($maxCachekeySize = 15);
-//15 is the default value
-//set to '0' to disable caching
-//a value between 10 and 20 seems to give the best result
-$formatter = new SqlFormatter($tokenizer);
+$formatter = new SqlFormatter(new Tokenizer());
 
 //the sample query file is filled with install scripts for PrestaShop
 //and some sample catalog data from Magento
@@ -41,7 +37,7 @@ $uend = memory_get_usage(true);
 $end  = microtime(true);
 ?>
 
-    <p>Formatted <?= $num ?> queries using a maxCachekeySize of <?= $maxCachekeySize ?></p>
+    <p>Formatted <?= $num ?> queries</p>
     <p>Average query length of <?= number_format($chars/$num, 5) ?> characters</p>
     <p>
         Took <?= number_format($end-$start, 5) ?> seconds total,
@@ -49,5 +45,3 @@ $end  = microtime(true);
         <?= number_format(1000*($end-$start)/$chars, 5) ?> seconds per 1000 characters
     </p>
     <p>Used <?= number_format($uend-$ustart) ?> bytes of memory</p>
-
-    <h3>Cache Stats</h3><pre><?= print_r($tokenizer->getCacheStats(), true) ?></pre>


### PR DESCRIPTION
It does not seem to be worth it.
Without cache: 0.01434 seconds for 41 queries
With cache:    0.01035 seconds per 1000 characters
It does bring benefit, but at the cost of complexity that prevents
further development like having tokens that are aware of their
neighbours.