### PR TITLE
Simplify code by precomputing precedence

### DIFF
--- a/src/SqlFormatter.php
+++ b/src/SqlFormatter.php
@@ -77,8 +77,14 @@ final class SqlFormatter
                 continue;
             }
 
-            $indexedTokens[] = ['originalIndex' => $i, 'token' => $token];
+            $indexedTokens[] = [
+                'wasPrecededByWhitespace' => ! isset($originalTokens[$i-1]) ||
+                    $originalTokens[$i-1]->isOfType(Token::TOKEN_TYPE_WHITESPACE),
+                'token' => $token,
+            ];
         }
+
+        unset($originalTokens);
 
         // Format token by token
         foreach ($indexedTokens as $i => $indexedToken) {
@@ -198,8 +204,7 @@ final class SqlFormatter
                 }
 
                 // Take out the preceding space unless there was whitespace there in the original query
-                if (isset($originalTokens[$indexedToken['originalIndex']-1]) &&
-                    ! $originalTokens[$indexedToken['originalIndex']-1]->isOfType(Token::TOKEN_TYPE_WHITESPACE)) {
+                if (! $indexedToken['wasPrecededByWhitespace']) {
                     $return = rtrim($return, ' ');
                 }
 
@@ -294,8 +299,7 @@ final class SqlFormatter
                 // Multiple boundary characters in a row should not have spaces between them (not including parentheses)
                 if (isset($indexedTokens[$i-1]) &&
                     $indexedTokens[$i-1]['token']->isOfType(Token::TOKEN_TYPE_BOUNDARY)) {
-                    if (isset($originalTokens[$indexedToken['originalIndex']-1]) &&
-                        ! $originalTokens[$indexedToken['originalIndex']-1]->isOfType(Token::TOKEN_TYPE_WHITESPACE)) {
+                    if (! $indexedToken['wasPrecededByWhitespace']) {
                         $return = rtrim($return, ' ');
                     }
                 }


### PR DESCRIPTION
# Before

    <p>Formatted 42 queries</p>
    <p>Average query length of 280.33333 characters</p>
    <p>
        Took 0.01447 seconds total,
        0.00034 seconds per query,
        0.00123 seconds per 1000 characters
    </p>
    <p>Used 0 bytes of memory</p>

# After

    <p>Formatted 42 queries</p>
    <p>Average query length of 280.33333 characters</p>
    <p>
        Took 0.01512 seconds total,
        0.00036 seconds per query,
        0.00128 seconds per 1000 characters
    </p>
    <p>Used 0 bytes of memory</p>

There's a small performance hit, but I think we can ignore it.