### PR TITLE
Adapt bin/sql-formatter to SqlFormatter API

### DIFF
--- a/bin/sql-formatter
+++ b/bin/sql-formatter
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+
 if("cli" !== php_sapi_name()) {
     echo "<p>Run this PHP script from the command line to see CLI syntax highlighting and formatting.  It supports Unix pipes or command line argument style.</p>";
     echo "<pre><code>php bin/sql-formatter \"SELECT * FROM MyTable WHERE (id>5 AND \\`name\\` LIKE \\&quot;testing\\&quot;);\"</code></pre>";
@@ -11,30 +12,9 @@ if(isset($argv[1])) {
     $sql = $argv[1];
 }
 else {
-    $sql = stream_get_contents(fopen("php://stdin", "r"));
+    $sql = stream_get_contents(fopen('php://stdin', 'r'));
 }
 
-require_once(__DIR__.'/../lib/SqlFormatter.php');
+require_once(__DIR__.'/../vendor/autoload.php');
 
-/**
- * Returns true if the stream supports colorization.
- *
- * Colorization is disabled if not supported by the stream:
- *
- *  -  Windows without Ansicon and ConEmu
- *  -  non tty consoles
- *
- * @return bool    true if the stream supports colorization, false otherwise
- * @link https://github.com/symfony/symfony/blob/v2.4.6/src/Symfony/Component/Console/Output/StreamOutput.php#L97
- */
-function hasColorSupport() {
-	if (DIRECTORY_SEPARATOR == '\\') {
-		return false !== getenv('ANSICON') || 'ON' === getenv('ConEmuANSI');
-	}
-
-	return function_exists('posix_isatty') && @posix_isatty(STDOUT);
-}
-
-$highlight = hasColorSupport();
-
-echo SqlFormatter::format($sql, $highlight);
+echo (new \Doctrine\SqlFormatter\SqlFormatter())->format($sql);


### PR DESCRIPTION
The sql-formatter in the bin directory was still using the old formatter API. I've adapted it to use `Doctrine\SqlFormatter\SqlFormatter`.