### PR TITLE
Option to force uppercase SQL keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ use Doctrine\SqlFormatter\SqlFormatter;
 echo (new SqlFormatter(new NullHighlighter()))->format($query);
 ```
 
+#### Forcing uppercase for SQL keywords
+
+If you wish to also force SQL keywords to be uppercase, you can do the following:
+
+```php
+<?php
+
+use Doctrine\SqlFormatter\NullHighlighter;
+use Doctrine\SqlFormatter\SqlFormatter;
+
+echo (new SqlFormatter(new NullHighlighter()))->format($query, '  ', true);
+```
+
 Output:
 
 ![](http://jdorn.github.com/sql-formatter/format.png)

--- a/src/SqlFormatter.php
+++ b/src/SqlFormatter.php
@@ -16,12 +16,14 @@ use function array_shift;
 use function array_unshift;
 use function assert;
 use function current;
+use function in_array;
 use function preg_replace;
 use function reset;
 use function rtrim;
 use function str_repeat;
 use function str_replace;
 use function strlen;
+use function strtoupper;
 use function trim;
 
 use const PHP_SAPI;
@@ -36,7 +38,7 @@ final class SqlFormatter
 
     public function __construct(?Highlighter $highlighter = null)
     {
-        $this->tokenizer = new Tokenizer();
+        $this->tokenizer   = new Tokenizer();
         $this->highlighter = $highlighter ?? (PHP_SAPI === 'cli' ? new CliHighlighter() : new HtmlHighlighter());
     }
 
@@ -75,11 +77,11 @@ final class SqlFormatter
             $uppercaseTypes = [
                 Token::TOKEN_TYPE_RESERVED,
                 Token::TOKEN_TYPE_RESERVED_NEWLINE,
-                Token::TOKEN_TYPE_RESERVED_TOPLEVEL
+                Token::TOKEN_TYPE_RESERVED_TOPLEVEL,
             ];
 
             // Uppercase transformation if desired
-            if ($forceUppercase && in_array($token->type(), $uppercaseTypes)) {                
+            if ($forceUppercase && in_array($token->type(), $uppercaseTypes)) {
                 $tokenValue = strtoupper($token->value());
             } else {
                 $tokenValue = $token->value();

--- a/src/SqlFormatter.php
+++ b/src/SqlFormatter.php
@@ -47,7 +47,7 @@ final class SqlFormatter
      *
      * @return string The SQL string with HTML styles and formatting wrapped in a <pre> tag
      */
-    public function format(string $string, string $indentString = '  '): string
+    public function format(string $string, string $indentString = '  ', bool $forceUppercase = false): string
     {
         // This variable will be populated with formatted html
         $return = '';
@@ -71,9 +71,23 @@ final class SqlFormatter
 
         // Format token by token
         while ($token = $cursor->next(Token::TOKEN_TYPE_WHITESPACE)) {
+            // Uppercase reserved words
+            $uppercaseTypes = [
+                Token::TOKEN_TYPE_RESERVED,
+                Token::TOKEN_TYPE_RESERVED_NEWLINE,
+                Token::TOKEN_TYPE_RESERVED_TOPLEVEL
+            ];
+
+            // Uppercase transformation if desired
+            if ($forceUppercase && in_array($token->type(), $uppercaseTypes)) {                
+                $tokenValue = strtoupper($token->value());
+            } else {
+                $tokenValue = $token->value();
+            }
+
             $highlighted = $this->highlighter->highlightToken(
                 $token->type(),
-                $token->value()
+                $tokenValue
             );
 
             // If we are increasing the special indent level now

--- a/src/SqlFormatter.php
+++ b/src/SqlFormatter.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SQL Formatter is a collection of utilities for debugging SQL queries.
  * It includes methods for formatting, syntax highlighting, removing comments, etc.
  *
- * @link       http://github.com/jdorn/sql-formatter
+ * @see http://github.com/jdorn/sql-formatter
  */
 
 namespace Doctrine\SqlFormatter;
@@ -36,7 +36,7 @@ final class SqlFormatter
 
     public function __construct(?Highlighter $highlighter = null)
     {
-        $this->tokenizer   = new Tokenizer();
+        $this->tokenizer = new Tokenizer();
         $this->highlighter = $highlighter ?? (PHP_SAPI === 'cli' ? new CliHighlighter() : new HtmlHighlighter());
     }
 

--- a/tests/SqlFormatterTest.php
+++ b/tests/SqlFormatterTest.php
@@ -60,6 +60,16 @@ final class SqlFormatterTest extends TestCase
         $this->assertEquals(trim($html), trim($formatter->format($sql)));
     }
 
+    public function testFormatUpperCase(): void
+    {
+        $formatter = new SqlFormatter(new NullHighlighter());
+
+        $actual = $formatter->format('select a from b where c = d;', ' ', true);
+        $expected = "SELECT\n a\nFROM\n b\nWHERE\n c = d;";
+
+        $this->assertEquals(trim($expected), trim($actual));
+    }
+
     /**
      * @dataProvider highlightData
      */

--- a/tests/SqlFormatterTest.php
+++ b/tests/SqlFormatterTest.php
@@ -64,7 +64,7 @@ final class SqlFormatterTest extends TestCase
     {
         $formatter = new SqlFormatter(new NullHighlighter());
 
-        $actual = $formatter->format('select a from b where c = d;', ' ', true);
+        $actual   = $formatter->format('select a from b where c = d;', ' ', true);
         $expected = "SELECT\n a\nFROM\n b\nWHERE\n c = d;";
 
         $this->assertEquals(trim($expected), trim($actual));


### PR DESCRIPTION
This adds a new optional third parameter to the `format` method, `$forceUppercase` which defaults to `false` to maintain backwards compatibility.

When passed as `true`, all keywords will be uppercased.

There is a new test written in for this functionality that passes.

Fixes: https://github.com/doctrine/sql-formatter/issues/32.
Implementation abstracted from the original PR against the forked source: https://github.com/jdorn/sql-formatter/pull/86