### PR TITLE
Allow require autoloader at bin installed under vendor

### DIFF
--- a/bin/sql-formatter
+++ b/bin/sql-formatter
@@ -15,6 +15,16 @@ else {
     $sql = stream_get_contents(fopen('php://stdin', 'r'));
 }
 
-require_once(__DIR__.'/../vendor/autoload.php');
+$autoloadFiles = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php'
+];
+
+foreach ($autoloadFiles as $autoloadFile) {
+    if (file_exists($autoloadFile)) {
+        require_once $autoloadFile;
+        break;
+    }
+}
 
 echo (new \Doctrine\SqlFormatter\SqlFormatter())->format($sql);


### PR DESCRIPTION
copy & pasted from 
https://github.com/doctrine/orm/blob/2.9.x/bin/doctrine.php

* currently, `bin/sql-formatter` could not be executable when installed via composer.

```
$ composer require --dev doctrine/sql-formatter
$ echo 'SELECT 1 FROM dual' | ./vendor/bin/sql-formatter
PHP Warning:  require_once(/mnt/d/dev/tmp/sql-formatter/vendor/doctrine/sql-formatter/bin/../vendor/autoload.php): Failed to open stream: No such file or directory in /mnt/d/dev/tmp/sql-formatter/vendor/doctrine/sql-formatter/bin/sql-formatter on line 18
```