### PR TITLE
Stop being strict about coverage metadata

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,8 +7,6 @@
          beStrictAboutOutputDuringTests="true"
          colors="true"
          cacheDirectory=".phpunit.cache"
-         requireCoverageMetadata="true"
-         beStrictAboutCoverageMetadata="true"
 >
     <testsuites>
         <testsuite name="default">

--- a/tests/SqlFormatterTest.php
+++ b/tests/SqlFormatterTest.php
@@ -9,7 +9,6 @@ use Doctrine\SqlFormatter\HtmlHighlighter;
 use Doctrine\SqlFormatter\NullHighlighter;
 use Doctrine\SqlFormatter\SqlFormatter;
 use Generator;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
@@ -23,7 +22,6 @@ use function pack;
 use function sprintf;
 use function trim;
 
-#[CoversClass(SqlFormatter::class)]
 final class SqlFormatterTest extends TestCase
 {
     private SqlFormatter $formatter;

--- a/tests/TokenizerTest.php
+++ b/tests/TokenizerTest.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\SqlFormatter\Tests;
 
 use Doctrine\SqlFormatter\Tokenizer;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(Tokenizer::class)]
 final class TokenizerTest extends TestCase
 {
     #[DoesNotPerformAssertions]


### PR DESCRIPTION
Right now it is only done on a single class, so we cannot be strict until we address that.

Follow-up to https://github.com/doctrine/sql-formatter/pull/103#issuecomment-2107377281