### PR TITLE
Make sure all lines are terminated by LF

### DIFF
--- a/src/CliHighlighter.php
+++ b/src/CliHighlighter.php
@@ -6,8 +6,6 @@ namespace Doctrine\SqlFormatter;
 
 use function sprintf;
 
-use const PHP_EOL;
-
 final class CliHighlighter implements Highlighter
 {
     public const HIGHLIGHT_FUNCTIONS = 'functions';
@@ -59,7 +57,7 @@ final class CliHighlighter implements Highlighter
     {
         return sprintf(
             '%s%s%s%s',
-            PHP_EOL,
+            "\n",
             $this->escapeSequences[self::HIGHLIGHT_ERROR],
             $value,
             "\x1b[0m",

--- a/src/HtmlHighlighter.php
+++ b/src/HtmlHighlighter.php
@@ -10,7 +10,6 @@ use function trim;
 
 use const ENT_COMPAT;
 use const ENT_IGNORE;
-use const PHP_EOL;
 
 final class HtmlHighlighter implements Highlighter
 {
@@ -70,7 +69,7 @@ final class HtmlHighlighter implements Highlighter
     {
         return sprintf(
             '%s<span %s>%s</span>',
-            PHP_EOL,
+            "\n",
             $this->htmlAttributes[self::HIGHLIGHT_ERROR],
             $value,
         );

--- a/tests/SqlFormatterTest.php
+++ b/tests/SqlFormatterTest.php
@@ -19,8 +19,8 @@ use function defined;
 use function explode;
 use function file_get_contents;
 use function pack;
+use function rtrim;
 use function sprintf;
-use function trim;
 
 final class SqlFormatterTest extends TestCase
 {
@@ -37,20 +37,20 @@ final class SqlFormatterTest extends TestCase
     #[DataProvider('formatHighlightData')]
     public function testFormatHighlight(string $sql, string $html): void
     {
-        $this->assertEquals(trim($html), trim($this->formatter->format($sql)));
+        $this->assertSame($html, $this->formatter->format($sql));
     }
 
     #[DataProvider('formatData')]
     public function testFormat(string $sql, string $html): void
     {
         $formatter = new SqlFormatter(new NullHighlighter());
-        $this->assertEquals(trim($html), trim($formatter->format($sql)));
+        $this->assertSame($html, $formatter->format($sql));
     }
 
     #[DataProvider('highlightData')]
     public function testHighlight(string $sql, string $html): void
     {
-        $this->assertEquals(trim($html), trim($this->formatter->highlight($sql)));
+        $this->assertSame($html, $this->formatter->highlight($sql));
     }
 
     public function testHighlightBinary(): void
@@ -69,20 +69,20 @@ final class SqlFormatterTest extends TestCase
             $binaryData .
             '</span> <span style="font-weight:bold;">AS</span> <span style="color: #333;">BINARY</span></pre>';
 
-        $this->assertEquals(trim($html), trim($this->formatter->highlight($sql)));
+        $this->assertSame($html, $this->formatter->highlight($sql));
     }
 
     #[DataProvider('highlightCliData')]
     public function testCliHighlight(string $sql, string $html): void
     {
         $formatter = new SqlFormatter(new CliHighlighter());
-        $this->assertEquals(trim($html), trim($formatter->format($sql)));
+        $this->assertSame($html . "\n", $formatter->format($sql));
     }
 
     #[DataProvider('compressData')]
     public function testCompress(string $sql, string $html): void
     {
-        $this->assertEquals(trim($html), trim($this->formatter->compress($sql)));
+        $this->assertSame($html, $this->formatter->compress($sql));
     }
 
     public function testUsePre(): void
@@ -90,13 +90,13 @@ final class SqlFormatterTest extends TestCase
         $formatter = new SqlFormatter(new HtmlHighlighter([], false));
         $actual    = $formatter->highlight('test');
         $expected  = '<span style="color: #333;">test</span>';
-        $this->assertEquals($actual, $expected);
+        $this->assertSame($actual, $expected);
 
         $formatter = new SqlFormatter(new HtmlHighlighter([], true));
         $actual    = $formatter->highlight('test');
         $expected  = '<pre style="color: black; background-color: white;">' .
             '<span style="color: #333;">test</span></pre>';
-        $this->assertEquals($actual, $expected);
+        $this->assertSame($actual, $expected);
     }
 
     /** @return Generator<mixed[]> */
@@ -104,7 +104,7 @@ final class SqlFormatterTest extends TestCase
     {
         $contents = file_get_contents(__DIR__ . '/' . $file);
         assert($contents !== false);
-        $formatHighlightData = explode("\n---\n", $contents);
+        $formatHighlightData = explode("\n---\n", rtrim($contents, "\n"));
         $sqlData             = self::sqlData();
         if (count($formatHighlightData) !== count($sqlData)) {
             throw new UnexpectedValueException(sprintf(
@@ -156,6 +156,6 @@ final class SqlFormatterTest extends TestCase
         $contents = file_get_contents(__DIR__ . '/sql.sql');
         assert($contents !== false);
 
-        return explode("\n---\n", $contents);
+        return explode("\n---\n", rtrim($contents, "\n"));
     }
 }


### PR DESCRIPTION
Without this fix tests are failing on Windows:

```
There were 2 failures:

1) Doctrine\SqlFormatter\Tests\SqlFormatterTest::testFormatHighlight with data set #33 ('SELECT Test FROM Test WHERE\n... = 2);', '<pre style="color: black; bac...</pre>')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 <span style="font-weight:bold;">FROM</span>\n
   <span style="color: #333;">Test</span>\n
 <span style="font-weight:bold;">WHERE</span>\n
-  (<span style="color: #333;">MyColumn</span> <span >=</span> <span style="color: green;">1</span>)\n
+  (<span style="color: #333;">MyColumn</span> <span >=</span> <span style="color: green;">1</span>)\r\n
 <span style="background-color: red;">)</span>\n
 <span style="font-weight:bold;">AND</span> (\n
   (\n
-    (<span style="color: #333;">SomeOtherColumn</span> <span >=</span> <span style="color: green;">2</span>)<span >;</span>\n
+    (<span style="color: #333;">SomeOtherColumn</span> <span >=</span> <span style="color: green;">2</span>)<span >;</span>\r\n
 <span style="background-color: red;">WARNING: unclosed parentheses or section</span></pre>'

2) Doctrine\SqlFormatter\Tests\SqlFormatterTest::testCliHighlight with data set #33 ('SELECT Test FROM Test WHERE\n... = 2);', 'SELECT\n  Test\n...on')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 FROM\n
   Test\n
 WHERE\n
-  (MyColumn = 1)\n
+  (MyColumn = 1)\r\n
 )\n
 AND (\n
   (\n
-    (SomeOtherColumn = 2);\n
+    (SomeOtherColumn = 2);\r\n
 WARNING: unclosed parentheses or section'
```

As all other line ends use LF solely, lets use LF also for these two error formatters.