### PR TITLE
Fix unopened END indent opened by BEGIN

### DIFF
--- a/tests/clihighlight.txt
+++ b/tests/clihighlight.txt
@@ -1021,18 +1021,19 @@ MY_NON_TOP_LEVEL_KEYWORD_FX_2[0m();[0m
       [32;1m1[0m [37mas[0m x[0m
   );[0m
 MY_NON_TOP_LEVEL_KEYWORD_FX_3[0m();[0m
-[37mBEGIN[0m MY_NON_TOP_LEVEL_KEYWORD_FX_4[0m();[0m
-MY_NON_TOP_LEVEL_KEYWORD_FX_5[0m();[0m
+[37mBEGIN[0m
+  MY_NON_TOP_LEVEL_KEYWORD_FX_4[0m();[0m
+  MY_NON_TOP_LEVEL_KEYWORD_FX_5[0m();[0m
 [37mEND[0m;[0m
 [37mBEGIN[0m
-[37mSELECT[0m
-  x[0m
-[37mFROM[0m
-  (
-    [37mSELECT[0m
-      [32;1m1[0m [37mas[0m x[0m
-  );[0m
-MY_NON_TOP_LEVEL_KEYWORD_FX_6[0m();[0m
+  [37mSELECT[0m
+    x[0m
+  [37mFROM[0m
+    (
+      [37mSELECT[0m
+        [32;1m1[0m [37mas[0m x[0m
+    );[0m
+  MY_NON_TOP_LEVEL_KEYWORD_FX_6[0m();[0m
 [37mEND[0m;[0m
 ---
 [37mSELECT[0m
@@ -1070,3 +1071,30 @@ MY_NON_TOP_LEVEL_KEYWORD_FX_6[0m();[0m
   name[0m
 [37mFROM[0m
   user[0m
+---
+[37mbegin[0m
+  try[0m [37minsert[0m [37minto[0m [35;1m[t][0m ([35;1m[name][0m,[0m [35;1m[int][0m,[0m [35;1m[float][0m,[0m [35;1m[null][0m)
+  [37mvalues[0m
+    (N[0m [34;1m'Ewa'[0m,[0m [32;1m1[0m,[0m [32;1m1.0[0m,[0m [37mnull[0m);[0m
+[37mend[0m try[0m [37mbegin[0m
+  catch[0m [37mif[0m ERROR_NUMBER[0m() =[0m [32;1m544[0m [37mbegin[0m
+    [37mset[0m
+      IDENTITY_INSERT[0m [35;1m[t][0m [37mon[0m;[0m
+    [37mbegin[0m
+      try[0m [37minsert[0m [37minto[0m [35;1m[t][0m ([35;1m[name][0m,[0m [35;1m[int][0m,[0m [35;1m[float][0m,[0m [35;1m[null][0m)
+      [37mvalues[0m
+        (N[0m [34;1m'Ewa'[0m,[0m [32;1m1[0m,[0m [32;1m1.0[0m,[0m [37mnull[0m);[0m
+      [37mset[0m
+        IDENTITY_INSERT[0m [35;1m[t][0m off[0m;[0m
+    [37mend[0m try[0m [37mbegin[0m
+      catch[0m
+      [37mset[0m
+        IDENTITY_INSERT[0m [35;1m[t][0m off[0m;[0m
+      throw[0m;[0m
+    [37mend[0m catch[0m
+  [37mend[0m
+[37melse[0m
+  [37mbegin[0m
+    throw[0m;[0m
+  [37mend[0m
+[37mend[0m catch[0m

--- a/tests/compress.txt
+++ b/tests/compress.txt
@@ -97,3 +97,5 @@ SELECT 1::text;
 MY_NON_TOP_LEVEL_KEYWORD_FX_1(); MY_NON_TOP_LEVEL_KEYWORD_FX_2(); SELECT x FROM (SELECT 1 as x); MY_NON_TOP_LEVEL_KEYWORD_FX_3(); BEGIN MY_NON_TOP_LEVEL_KEYWORD_FX_4(); MY_NON_TOP_LEVEL_KEYWORD_FX_5(); END; BEGIN SELECT x FROM (SELECT 1 as x); MY_NON_TOP_LEVEL_KEYWORD_FX_6(); END;
 ---
 SELECT case when name = 1 then 10 when name = 2 then 20 when name = 3 then case when age > 10 then 30 else 31 end else 40 end AS case1, (SELECT case name when 1 then 10 when 2 then 20 when 3 then case age when 10 then 30 else 31 end else 40 end) case2, name FROM user
+---
+begin try insert into [t] ([name], [int], [float], [null]) values (N'Ewa', 1, 1.0, null); end try begin catch if ERROR_NUMBER() = 544 begin set IDENTITY_INSERT [t] on; begin try insert into [t] ([name], [int], [float], [null]) values (N'Ewa', 1, 1.0, null); set IDENTITY_INSERT [t] off; end try begin catch set IDENTITY_INSERT [t] off; throw; end catch end else begin throw; end end catch

--- a/tests/format-highlight.html
+++ b/tests/format-highlight.html
@@ -1021,18 +1021,19 @@
       <span style="color: green;">1</span> <span style="font-weight:bold;">as</span> <span style="color: #333;">x</span>
   )<span >;</span>
 <span style="color: #333;">MY_NON_TOP_LEVEL_KEYWORD_FX_3</span>()<span >;</span>
-<span style="font-weight:bold;">BEGIN</span> <span style="color: #333;">MY_NON_TOP_LEVEL_KEYWORD_FX_4</span>()<span >;</span>
-<span style="color: #333;">MY_NON_TOP_LEVEL_KEYWORD_FX_5</span>()<span >;</span>
+<span style="font-weight:bold;">BEGIN</span>
+  <span style="color: #333;">MY_NON_TOP_LEVEL_KEYWORD_FX_4</span>()<span >;</span>
+  <span style="color: #333;">MY_NON_TOP_LEVEL_KEYWORD_FX_5</span>()<span >;</span>
 <span style="font-weight:bold;">END</span><span >;</span>
 <span style="font-weight:bold;">BEGIN</span>
-<span style="font-weight:bold;">SELECT</span>
-  <span style="color: #333;">x</span>
-<span style="font-weight:bold;">FROM</span>
-  (
-    <span style="font-weight:bold;">SELECT</span>
-      <span style="color: green;">1</span> <span style="font-weight:bold;">as</span> <span style="color: #333;">x</span>
-  )<span >;</span>
-<span style="color: #333;">MY_NON_TOP_LEVEL_KEYWORD_FX_6</span>()<span >;</span>
+  <span style="font-weight:bold;">SELECT</span>
+    <span style="color: #333;">x</span>
+  <span style="font-weight:bold;">FROM</span>
+    (
+      <span style="font-weight:bold;">SELECT</span>
+        <span style="color: green;">1</span> <span style="font-weight:bold;">as</span> <span style="color: #333;">x</span>
+    )<span >;</span>
+  <span style="color: #333;">MY_NON_TOP_LEVEL_KEYWORD_FX_6</span>()<span >;</span>
 <span style="font-weight:bold;">END</span><span >;</span></pre>
 ---
 <pre style="color: black; background-color: white;"><span style="font-weight:bold;">SELECT</span>
@@ -1070,3 +1071,30 @@
   <span style="color: #333;">name</span>
 <span style="font-weight:bold;">FROM</span>
   <span style="color: #333;">user</span></pre>
+---
+<pre style="color: black; background-color: white;"><span style="font-weight:bold;">begin</span>
+  <span style="color: #333;">try</span> <span style="font-weight:bold;">insert</span> <span style="font-weight:bold;">into</span> <span style="color: purple;">[t]</span> (<span style="color: purple;">[name]</span><span >,</span> <span style="color: purple;">[int]</span><span >,</span> <span style="color: purple;">[float]</span><span >,</span> <span style="color: purple;">[null]</span>)
+  <span style="font-weight:bold;">values</span>
+    (<span style="color: #333;">N</span> <span style="color: blue;">'Ewa'</span><span >,</span> <span style="color: green;">1</span><span >,</span> <span style="color: green;">1.0</span><span >,</span> <span style="font-weight:bold;">null</span>)<span >;</span>
+<span style="font-weight:bold;">end</span> <span style="color: #333;">try</span> <span style="font-weight:bold;">begin</span>
+  <span style="color: #333;">catch</span> <span style="font-weight:bold;">if</span> <span style="color: #333;">ERROR_NUMBER</span>() <span >=</span> <span style="color: green;">544</span> <span style="font-weight:bold;">begin</span>
+    <span style="font-weight:bold;">set</span>
+      <span style="color: #333;">IDENTITY_INSERT</span> <span style="color: purple;">[t]</span> <span style="font-weight:bold;">on</span><span >;</span>
+    <span style="font-weight:bold;">begin</span>
+      <span style="color: #333;">try</span> <span style="font-weight:bold;">insert</span> <span style="font-weight:bold;">into</span> <span style="color: purple;">[t]</span> (<span style="color: purple;">[name]</span><span >,</span> <span style="color: purple;">[int]</span><span >,</span> <span style="color: purple;">[float]</span><span >,</span> <span style="color: purple;">[null]</span>)
+      <span style="font-weight:bold;">values</span>
+        (<span style="color: #333;">N</span> <span style="color: blue;">'Ewa'</span><span >,</span> <span style="color: green;">1</span><span >,</span> <span style="color: green;">1.0</span><span >,</span> <span style="font-weight:bold;">null</span>)<span >;</span>
+      <span style="font-weight:bold;">set</span>
+        <span style="color: #333;">IDENTITY_INSERT</span> <span style="color: purple;">[t]</span> <span style="color: #333;">off</span><span >;</span>
+    <span style="font-weight:bold;">end</span> <span style="color: #333;">try</span> <span style="font-weight:bold;">begin</span>
+      <span style="color: #333;">catch</span>
+      <span style="font-weight:bold;">set</span>
+        <span style="color: #333;">IDENTITY_INSERT</span> <span style="color: purple;">[t]</span> <span style="color: #333;">off</span><span >;</span>
+      <span style="color: #333;">throw</span><span >;</span>
+    <span style="font-weight:bold;">end</span> <span style="color: #333;">catch</span>
+  <span style="font-weight:bold;">end</span>
+<span style="font-weight:bold;">else</span>
+  <span style="font-weight:bold;">begin</span>
+    <span style="color: #333;">throw</span><span >;</span>
+  <span style="font-weight:bold;">end</span>
+<span style="font-weight:bold;">end</span> <span style="color: #333;">catch</span></pre>

--- a/tests/format.txt
+++ b/tests/format.txt
@@ -1019,18 +1019,19 @@ FROM
       1 as x
   );
 MY_NON_TOP_LEVEL_KEYWORD_FX_3();
-BEGIN MY_NON_TOP_LEVEL_KEYWORD_FX_4();
-MY_NON_TOP_LEVEL_KEYWORD_FX_5();
+BEGIN
+  MY_NON_TOP_LEVEL_KEYWORD_FX_4();
+  MY_NON_TOP_LEVEL_KEYWORD_FX_5();
 END;
 BEGIN
-SELECT
-  x
-FROM
-  (
-    SELECT
-      1 as x
-  );
-MY_NON_TOP_LEVEL_KEYWORD_FX_6();
+  SELECT
+    x
+  FROM
+    (
+      SELECT
+        1 as x
+    );
+  MY_NON_TOP_LEVEL_KEYWORD_FX_6();
 END;
 ---
 SELECT
@@ -1068,3 +1069,30 @@ SELECT
   name
 FROM
   user
+---
+begin
+  try insert into [t] ([name], [int], [float], [null])
+  values
+    (N 'Ewa', 1, 1.0, null);
+end try begin
+  catch if ERROR_NUMBER() = 544 begin
+    set
+      IDENTITY_INSERT [t] on;
+    begin
+      try insert into [t] ([name], [int], [float], [null])
+      values
+        (N 'Ewa', 1, 1.0, null);
+      set
+        IDENTITY_INSERT [t] off;
+    end try begin
+      catch
+      set
+        IDENTITY_INSERT [t] off;
+      throw;
+    end catch
+  end
+else
+  begin
+    throw;
+  end
+end catch

--- a/tests/highlight.html
+++ b/tests/highlight.html
@@ -356,3 +356,27 @@ JOIN</span> <span style="color: #333;">c</span> <span style="font-weight:bold;">
   <span style="color: #333;">name</span>
 <span style="font-weight:bold;">FROM</span>
   <span style="color: #333;">user</span></pre>
+---
+<pre style="color: black; background-color: white;"><span style="font-weight:bold;">begin</span> <span style="color: #333;">try</span>
+  <span style="font-weight:bold;">insert</span> <span style="font-weight:bold;">into</span> <span style="color: purple;">[t]</span> (<span style="color: purple;">[name]</span><span >,</span> <span style="color: purple;">[int]</span><span >,</span> <span style="color: purple;">[float]</span><span >,</span> <span style="color: purple;">[null]</span>)
+  <span style="font-weight:bold;">values</span> (<span style="color: #333;">N</span><span style="color: blue;">'Ewa'</span><span >,</span> <span style="color: green;">1</span><span >,</span> <span style="color: green;">1.0</span><span >,</span> <span style="font-weight:bold;">null</span>)<span >;</span>
+<span style="font-weight:bold;">end</span> <span style="color: #333;">try</span>
+<span style="font-weight:bold;">begin</span> <span style="color: #333;">catch</span>
+  <span style="font-weight:bold;">if</span> <span style="color: #333;">ERROR_NUMBER</span>() <span >=</span> <span style="color: green;">544</span>
+    <span style="font-weight:bold;">begin</span>
+      <span style="font-weight:bold;">set</span> <span style="color: #333;">IDENTITY_INSERT</span> <span style="color: purple;">[t]</span> <span style="font-weight:bold;">on</span><span >;</span>
+      <span style="font-weight:bold;">begin</span> <span style="color: #333;">try</span>
+        <span style="font-weight:bold;">insert</span> <span style="font-weight:bold;">into</span> <span style="color: purple;">[t]</span> (<span style="color: purple;">[name]</span><span >,</span> <span style="color: purple;">[int]</span><span >,</span> <span style="color: purple;">[float]</span><span >,</span> <span style="color: purple;">[null]</span>)
+          <span style="font-weight:bold;">values</span> (<span style="color: #333;">N</span><span style="color: blue;">'Ewa'</span><span >,</span> <span style="color: green;">1</span><span >,</span> <span style="color: green;">1.0</span><span >,</span> <span style="font-weight:bold;">null</span>)<span >;</span>
+        <span style="font-weight:bold;">set</span> <span style="color: #333;">IDENTITY_INSERT</span> <span style="color: purple;">[t]</span> <span style="color: #333;">off</span><span >;</span>
+      <span style="font-weight:bold;">end</span> <span style="color: #333;">try</span>
+      <span style="font-weight:bold;">begin</span> <span style="color: #333;">catch</span>
+        <span style="font-weight:bold;">set</span> <span style="color: #333;">IDENTITY_INSERT</span> <span style="color: purple;">[t]</span> <span style="color: #333;">off</span><span >;</span>
+        <span style="color: #333;">throw</span><span >;</span>
+      <span style="font-weight:bold;">end</span> <span style="color: #333;">catch</span>
+    <span style="font-weight:bold;">end</span>
+  <span style="font-weight:bold;">else</span>
+    <span style="font-weight:bold;">begin</span>
+      <span style="color: #333;">throw</span><span >;</span>
+    <span style="font-weight:bold;">end</span>
+<span style="font-weight:bold;">end</span> <span style="color: #333;">catch</span></pre>

--- a/tests/sql.sql
+++ b/tests/sql.sql
@@ -356,3 +356,27 @@ SELECT
   name
 FROM
   user
+---
+begin try
+  insert into [t] ([name], [int], [float], [null])
+  values (N'Ewa', 1, 1.0, null);
+end try
+begin catch
+  if ERROR_NUMBER() = 544
+    begin
+      set IDENTITY_INSERT [t] on;
+      begin try
+        insert into [t] ([name], [int], [float], [null])
+          values (N'Ewa', 1, 1.0, null);
+        set IDENTITY_INSERT [t] off;
+      end try
+      begin catch
+        set IDENTITY_INSERT [t] off;
+        throw;
+      end catch
+    end
+  else
+    begin
+      throw;
+    end
+end catch


### PR DESCRIPTION
needs #110 (into 1.4.x as bugfix) and #114 (fix merge conflicts)

fix #101 (`END` indentation when used with `BEGIN`)

grammars:
- https://learn.microsoft.com/en-us/sql/t-sql/language-elements/begin-end-transact-sql?view=sql-server-ver16
- https://learn.microsoft.com/en-us/sql/t-sql/language-elements/try-catch-transact-sql?view=sql-server-ver16