### PR TITLE
Do not reallocate whole input string when matching next token

### DIFF
--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -868,7 +868,7 @@ final class Tokenizer
                 ($stringSlow[0] === '`' || $stringSlow[0] === '['
                     ? Token::TOKEN_TYPE_BACKTICK_QUOTE
                     : Token::TOKEN_TYPE_QUOTE),
-                $this->getNextQuotedString($stringSlow),
+                $this->getNextQuotedString($string, $offset),
             );
         }
 
@@ -879,7 +879,7 @@ final class Tokenizer
 
             // If the variable name is quoted
             if ($stringSlow[1] === '"' || $stringSlow[1] === '\'' || $stringSlow[1] === '`') {
-                $value = $stringSlow[0] . $this->getNextQuotedString(substr($stringSlow, 1));
+                $value = $stringSlow[0] . $this->getNextQuotedString($string, $offset + 1);
             } else {
                 // Non-quoted variable name
                 preg_match('/\G(' . $stringSlow[0] . '[\w.$]+)/', $stringSlow, $matches);
@@ -988,7 +988,7 @@ final class Tokenizer
         );
     }
 
-    private function getNextQuotedString(string $string): string
+    private function getNextQuotedString(string $string, int $offset): string
     {
         $ret = '';
 
@@ -1009,6 +1009,8 @@ final class Tokenizer
                     EOD,
                 $string,
                 $matches,
+                0,
+                $offset,
             )
         ) {
             $ret = $matches[0];

--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -833,7 +833,7 @@ final class Tokenizer
 
         $matches = [];
         // Whitespace
-        if (preg_match('/^\s+/', $stringSlow, $matches)) {
+        if (preg_match('/\G\s+/', $stringSlow, $matches)) {
             return new Token(Token::TOKEN_TYPE_WHITESPACE, $matches[0]);
         }
 
@@ -882,7 +882,7 @@ final class Tokenizer
                 $value = $stringSlow[0] . $this->getNextQuotedString(substr($stringSlow, 1));
             } else {
                 // Non-quoted variable name
-                preg_match('/^(' . $stringSlow[0] . '[\w.$]+)/', $stringSlow, $matches);
+                preg_match('/\G(' . $stringSlow[0] . '[\w.$]+)/', $stringSlow, $matches);
                 if ($matches) {
                     $value = $matches[1];
                 }
@@ -896,7 +896,7 @@ final class Tokenizer
         // Number (decimal, binary, or hex)
         if (
             preg_match(
-                '/^(\d+(\.\d+)?|0x[\da-fA-F]+|0b[01]+)($|\s|"\'`|' . $this->regexBoundaries . ')/',
+                '/\G(\d+(\.\d+)?|0x[\da-fA-F]+|0b[01]+)($|\s|"\'`|' . $this->regexBoundaries . ')/',
                 $stringSlow,
                 $matches,
             )
@@ -905,7 +905,7 @@ final class Tokenizer
         }
 
         // Boundary Character (punctuation and symbols)
-        if (preg_match('/^(' . $this->regexBoundaries . ')/', $stringSlow, $matches)) {
+        if (preg_match('/\G(' . $this->regexBoundaries . ')/', $stringSlow, $matches)) {
             return new Token(Token::TOKEN_TYPE_BOUNDARY, $matches[1]);
         }
 
@@ -916,7 +916,7 @@ final class Tokenizer
             // Top Level Reserved Word
             if (
                 preg_match(
-                    '/^(' . $this->regexReservedToplevel . ')($|\s|' . $this->regexBoundaries . ')/',
+                    '/\G(' . $this->regexReservedToplevel . ')($|\s|' . $this->regexBoundaries . ')/',
                     $upper,
                     $matches,
                 )
@@ -930,7 +930,7 @@ final class Tokenizer
             // Newline Reserved Word
             if (
                 preg_match(
-                    '/^(' . $this->regexReservedNewline . ')($|\s|' . $this->regexBoundaries . ')/',
+                    '/\G(' . $this->regexReservedNewline . ')($|\s|' . $this->regexBoundaries . ')/',
                     $upper,
                     $matches,
                 )
@@ -944,7 +944,7 @@ final class Tokenizer
             // Other Reserved Word
             if (
                 preg_match(
-                    '/^(' . $this->regexReserved . ')($|\s|' . $this->regexBoundaries . ')/',
+                    '/\G(' . $this->regexReserved . ')($|\s|' . $this->regexBoundaries . ')/',
                     $upper,
                     $matches,
                 )
@@ -960,7 +960,7 @@ final class Tokenizer
         // this makes it so "count(" is considered a function, but "count" alone is not
         $upper = strtoupper($stringSlow);
         // function
-        if (preg_match('/^(' . $this->regexFunction . '[(]|\s|[)])/', $upper, $matches)) {
+        if (preg_match('/\G(' . $this->regexFunction . '[(]|\s|[)])/', $upper, $matches)) {
             return new Token(
                 Token::TOKEN_TYPE_RESERVED,
                 substr($stringSlow, 0, strlen($matches[1]) - 1),
@@ -968,7 +968,7 @@ final class Tokenizer
         }
 
         // Non reserved word
-        preg_match('/^(.*?)($|\s|["\'`]|' . $this->regexBoundaries . ')/', $stringSlow, $matches);
+        preg_match('/\G(.*?)($|\s|["\'`]|' . $this->regexBoundaries . ')/', $stringSlow, $matches);
 
         return new Token(Token::TOKEN_TYPE_WORD, $matches[1]);
     }
@@ -1000,7 +1000,7 @@ final class Tokenizer
         if (
             preg_match(
                 <<<'EOD'
-                    ~^(?>(?sx)
+                    ~\G(?>(?sx)
                         (?:`[^`]*(?:$|`))+
                         |(?:\[[^\]]*($|\]))(?:\][^\]]*(?:$|\]))*
                         |(?:"[^"\\]*(?:\\.[^"\\]*)*(?:"|$))+

--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -912,13 +912,14 @@ final class Tokenizer
         // A reserved word cannot be preceded by a '.'
         // this makes it so in "mytable.from", "from" is not considered a reserved word
         if ($previous === null || $previous->value() !== '.') {
-            $upper = strtoupper($stringSlow);
             // Top Level Reserved Word
             if (
                 preg_match(
                     '/\G(' . $this->regexReservedToplevel . ')($|\s|' . $this->regexBoundaries . ')/',
                     $upper,
                     $matches,
+                    0,
+                    $offset,
                 )
             ) {
                 return new Token(
@@ -933,6 +934,8 @@ final class Tokenizer
                     '/\G(' . $this->regexReservedNewline . ')($|\s|' . $this->regexBoundaries . ')/',
                     $upper,
                     $matches,
+                    0,
+                    $offset,
                 )
             ) {
                 return new Token(
@@ -947,6 +950,8 @@ final class Tokenizer
                     '/\G(' . $this->regexReserved . ')($|\s|' . $this->regexBoundaries . ')/',
                     $upper,
                     $matches,
+                    0,
+                    $offset,
                 )
             ) {
                 return new Token(
@@ -958,9 +963,8 @@ final class Tokenizer
 
         // A function must be succeeded by '('
         // this makes it so "count(" is considered a function, but "count" alone is not
-        $upper = strtoupper($stringSlow);
         // function
-        if (preg_match('/\G(' . $this->regexFunction . '[(]|\s|[)])/', $upper, $matches)) {
+        if (preg_match('/\G(' . $this->regexFunction . '[(]|\s|[)])/', $upper, $matches, 0, $offset)) {
             return new Token(
                 Token::TOKEN_TYPE_RESERVED,
                 substr($stringSlow, 0, strlen($matches[1]) - 1),


### PR DESCRIPTION
Purely a performance refactoring.

The measured performance improvement is about -90% reduced runtime for the included test. With larger test/SQL, the speedup is even more dramatic as the original complexity was O(N^2).

Originally, the whole input string was reallocated after each token in:
- https://github.com/doctrine/sql-formatter/blob/1.4.0/src/Tokenizer.php#L790

such big temporary string was upper cased for each token matching in:
- https://github.com/doctrine/sql-formatter/blob/1.4.0/src/Tokenizer.php#L890

~and regex patterns were constructed for each token matching freshly in:~ (extracted into another PR)
- https://github.com/doctrine/sql-formatter/blob/1.4.0/src/Tokenizer.php#L874

All such operations should be avoided for linear scalability and this PR addresses that.