### PR TITLE
Add support for PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "type": "library",
     "require": {
-        "php": "^8.1"
+        "php": "^8.1 || ^8.2"
     },
     "require-dev": {
         "doctrine/coding-standard": "^12",


### PR DESCRIPTION
Added PHP 8.2 support to `composer.json`.
The codebase is already ready for PHP 8.2, so no changes to PHP code needed.