### PR TITLE
Update tokenizer to understand that WITH from "WITH TIMEZONE"  does not require a new line

### DIFF
--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -722,6 +722,12 @@ final class Tokenizer
         'YEARWEEK',
     ];
 
+    /** @var list<string> */
+    private array $dataTypeModifiers = [
+        'WITH TIME ZONE',
+        'WITHOUT TIME ZONE',
+    ];
+
     /** Regular expression for tokenizing. */
     private readonly string $tokenizeRegex;
 
@@ -834,11 +840,13 @@ final class Tokenizer
     private function makeTokenizeRegexes(): array
     {
         // Set up regular expressions
+
         $regexBoundaries       = $this->makeRegexFromList($this->boundaries);
         $regexReserved         = $this->makeRegexFromList($this->reserved);
         $regexReservedToplevel = str_replace(' ', '\s+', $this->makeRegexFromList($this->reservedToplevel));
         $regexReservedNewline  = str_replace(' ', '\s+', $this->makeRegexFromList($this->reservedNewline));
         $regexFunction         = $this->makeRegexFromList($this->functions);
+        $regexDataTypeModifiers = str_replace(' ', '\s+', $this->makeRegexFromList($this->dataTypeModifiers));
 
         return [
             Token::TOKEN_TYPE_WHITESPACE => '\s+',
@@ -866,6 +874,10 @@ final class Tokenizer
             Token::TOKEN_TYPE_NUMBER => '(?:\d+(?:\.\d+)?|0x[\da-fA-F]+|0b[01]+)(?=$|\s|"\'`|' . $regexBoundaries . ')',
             // punctuation and symbols
             Token::TOKEN_TYPE_BOUNDARY => $regexBoundaries,
+            // data type modifiers, this make 'WITH TIMEZONE' to be different from the 'WITH" from CTE
+            Token::TOKEN_TYPE_RESERVED => '(?<!\.)' . $regexDataTypeModifiers . '(?=$|\s|' . $regexBoundaries . ')'
+                . '|(?<!\.)' . $regexReserved . '(?=$|\s|' . $regexBoundaries . ')'
+                . '|' . $regexFunction . '(?=\s*\()',
             // A reserved word cannot be preceded by a '.'
             // this makes it so in "mytable.from", "from" is not considered a reserved word
             Token::TOKEN_TYPE_RESERVED_TOPLEVEL => '(?<!\.|\sCHARACTER\s(?=SET\s))' . $regexReservedToplevel . '(?=$|\s|' . $regexBoundaries . ')',

--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -841,11 +841,11 @@ final class Tokenizer
     {
         // Set up regular expressions
 
-        $regexBoundaries       = $this->makeRegexFromList($this->boundaries);
-        $regexReserved         = $this->makeRegexFromList($this->reserved);
-        $regexReservedToplevel = str_replace(' ', '\s+', $this->makeRegexFromList($this->reservedToplevel));
-        $regexReservedNewline  = str_replace(' ', '\s+', $this->makeRegexFromList($this->reservedNewline));
-        $regexFunction         = $this->makeRegexFromList($this->functions);
+        $regexBoundaries        = $this->makeRegexFromList($this->boundaries);
+        $regexReserved          = $this->makeRegexFromList($this->reserved);
+        $regexReservedToplevel  = str_replace(' ', '\s+', $this->makeRegexFromList($this->reservedToplevel));
+        $regexReservedNewline   = str_replace(' ', '\s+', $this->makeRegexFromList($this->reservedNewline));
+        $regexFunction          = $this->makeRegexFromList($this->functions);
         $regexDataTypeModifiers = str_replace(' ', '\s+', $this->makeRegexFromList($this->dataTypeModifiers));
 
         return [

--- a/tests/TokenizerTest.php
+++ b/tests/TokenizerTest.php
@@ -1658,6 +1658,38 @@ final class TokenizerTest extends TestCase
             ],
             '/* foo...',
         ];
+
+        yield 'WITH TIME ZONE as single token' => [
+            [
+                new Token(Token::TOKEN_TYPE_RESERVED, 'TIMESTAMP'),
+                new Token(Token::TOKEN_TYPE_BOUNDARY, '('),
+                new Token(Token::TOKEN_TYPE_NUMBER, '0'),
+                new Token(Token::TOKEN_TYPE_BOUNDARY, ')'),
+                new Token(Token::TOKEN_TYPE_WHITESPACE, ' '),
+                new Token(Token::TOKEN_TYPE_RESERVED, 'WITH TIME ZONE'),
+            ],
+            'TIMESTAMP(0) WITH TIME ZONE',
+        ];
+        
+        yield 'WITHOUT TIME ZONE as single token' => [
+            [
+                new Token(Token::TOKEN_TYPE_RESERVED, 'TIME'),
+                new Token(Token::TOKEN_TYPE_WHITESPACE, ' '),
+                new Token(Token::TOKEN_TYPE_RESERVED, 'WITHOUT TIME ZONE'),
+            ],
+            'TIME WITHOUT TIME ZONE',
+        ];
+        
+        yield 'CTE WITH still works' => [
+            [
+                new Token(Token::TOKEN_TYPE_RESERVED_TOPLEVEL, 'WITH'),
+                new Token(Token::TOKEN_TYPE_WHITESPACE, ' '),
+                new Token(Token::TOKEN_TYPE_WORD, 'cte'),
+                new Token(Token::TOKEN_TYPE_WHITESPACE, ' '),
+                new Token(Token::TOKEN_TYPE_RESERVED, 'AS'),
+            ],
+            'WITH cte AS',
+        ];
     }
 
     public function testTokenizeLongConcat(): void

--- a/tests/TokenizerTest.php
+++ b/tests/TokenizerTest.php
@@ -1670,7 +1670,7 @@ final class TokenizerTest extends TestCase
             ],
             'TIMESTAMP(0) WITH TIME ZONE',
         ];
-        
+
         yield 'WITHOUT TIME ZONE as single token' => [
             [
                 new Token(Token::TOKEN_TYPE_RESERVED, 'TIME'),
@@ -1679,7 +1679,7 @@ final class TokenizerTest extends TestCase
             ],
             'TIME WITHOUT TIME ZONE',
         ];
-        
+
         yield 'CTE WITH still works' => [
             [
                 new Token(Token::TOKEN_TYPE_RESERVED_TOPLEVEL, 'WITH'),


### PR DESCRIPTION

otherwise it creates broken output like 


```sql
            CREATE TABLE whatever (
              id INT NOT NULL,
              last_modification_datetime TIMESTAMP(0)
              WITH
                TIME ZONE NOT NULL,
                creation_datetime TIMESTAMP(0)
              WITH
                TIME ZONE NOT NULL,
                hashed_token VARCHAR(512) DEFAULT NULL,
                PRIMARY KEY(id)
            )
```

instead of 

```sql
            CREATE TABLE whatever (
              id INT NOT NULL,
              last_modification_datetime TIMESTAMP(0)  WITH TIME ZONE NOT NULL,
              creation_datetime TIMESTAMP(0) WITH TIME ZONE NOT NULL,
              hashed_token VARCHAR(512) DEFAULT NULL,
              PRIMARY KEY(id)
            )
```