### PR TITLE
Bump dev tools and CI workflows

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,4 +11,4 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@10.1.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@12.0.0"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   phpunit:
     name: "PHPUnit"
-    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@10.1.0"
+    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@12.0.0"
     with:
       php-versions: '["8.1", "8.2", "8.3", "8.4"]'
     secrets:

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@10.1.0"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@12.0.0"
     secrets:
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
       GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,4 +11,4 @@ on:
 jobs:
   static-analysis:
     name: "Static Analysis"
-    uses: "doctrine/.github/.github/workflows/phpstan.yml@10.1.0"
+    uses: "doctrine/.github/.github/workflows/phpstan.yml@12.0.0"

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^14",
-        "ergebnis/phpunit-slow-test-detector": "^2.14",
-        "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^10.5"
+        "ergebnis/phpunit-slow-test-detector": "^2.20",
+        "phpstan/phpstan": "^2.1.31",
+        "phpunit/phpunit": "^10.5.58"
     },
     "authors": [
         {

--- a/tests/TokenizerTest.php
+++ b/tests/TokenizerTest.php
@@ -1607,7 +1607,7 @@ final class TokenizerTest extends TestCase
         }
 
         if (serialize($tokens) === serialize($expectedTokens)) { // optimize self::assertEquals() for large inputs
-            self::assertTrue(true);
+            self::assertTrue(true); // @phpstan-ignore staticMethod.alreadyNarrowedType
         } else {
             self::assertEquals($expectedTokens, $tokens);
         }


### PR DESCRIPTION
Replaces #160.

This PR:
* … bumps PHPStan to 2.1
* … all Doctrine workflows to v12
* … prevents PHPUnit from being downgraded in the `lowest` job.