### PR TITLE
Fix PHPStan error

### DIFF
--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -804,9 +804,9 @@ final class Tokenizer
         }
 
         if ($items !== []) {
-            $valuesBySharedPrefix[$prefix] = $items;
-            $items                         = [];
-            $prefix                        = null;
+            $valuesBySharedPrefix[(string) $prefix] = $items;
+            $items                                  = [];
+            $prefix                                 = null;
         }
 
         $regex = '(?>';


### PR DESCRIPTION
The new PHPStan version complains if we use expressions that can be `null` as array offsets.