### PR TITLE
Fix ValueError when formatting procedures using label syntax (bar:LOOP)

### DIFF
--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -862,7 +862,7 @@ final class Tokenizer
                 )
                 EOD,
             // User-defined variable, possibly with quoted name
-            Token::TOKEN_TYPE_VARIABLE => '[@:](?:[\w.$]++|(?&t_' . Token::TOKEN_TYPE_BACKTICK_QUOTE . ')|(?&t_' . Token::TOKEN_TYPE_QUOTE . '))',
+            Token::TOKEN_TYPE_VARIABLE => '(?:@|(?<!\w):)(?:[\w.$]++|(?&t_' . Token::TOKEN_TYPE_BACKTICK_QUOTE . ')|(?&t_' . Token::TOKEN_TYPE_QUOTE . '))',
             // decimal, binary, or hex
             Token::TOKEN_TYPE_NUMBER => '(?:\d+(?:\.\d+)?|0x[\da-fA-F]+|0b[01]+)(?=$|\s|"\'`|' . $regexBoundaries . ')',
             // punctuation and symbols

--- a/tests/TokenizerTest.php
+++ b/tests/TokenizerTest.php
@@ -1672,6 +1672,22 @@ final class TokenizerTest extends TestCase
             ],
             'select json #> null',
         ];
+
+        yield 'label directly followed by LOOP is not a bind variable' => [
+            [
+                new Token(Token::TOKEN_TYPE_WORD, 'bar'),
+                new Token(Token::TOKEN_TYPE_BOUNDARY, ':'),
+                new Token(Token::TOKEN_TYPE_WORD, 'loop'),
+            ],
+            'bar:loop',
+        ];
+
+        yield 'bind variable' => [
+            [
+                new Token(Token::TOKEN_TYPE_VARIABLE, ':param'),
+            ],
+            ':param',
+        ];
     }
 
     public function testTokenizeLongConcat(): void

--- a/tests/clihighlight.txt
+++ b/tests/clihighlight.txt
@@ -1214,3 +1214,9 @@ MY_NON_TOP_LEVEL_KEYWORD_FX_3[0m();[0m
 ---
 [37mSELECT[0m
   text[0m ~*[0m [34;1m'\w+'[0m
+---
+[37mCREATE[0m [37mPROCEDURE[0m [35;1m`foo`[0m() [37mBEGIN[0m
+  bar[0m :[0m LOOP[0m
+    [30;1m-- Nothing[0m
+  [37mEND[0m LOOP[0m bar[0m;[0m
+[37mEND[0m

--- a/tests/compress.txt
+++ b/tests/compress.txt
@@ -117,3 +117,5 @@ SELECT '{}'::json #> '{}'
 SELECT vector1 <#> vector2
 ---
 SELECT text ~* '\w+'
+---
+CREATE PROCEDURE `foo`() BEGIN bar:LOOP END LOOP bar; END

--- a/tests/format-highlight.html
+++ b/tests/format-highlight.html
@@ -1214,3 +1214,9 @@
 ---
 <pre style="color: black; background-color: white;"><span style="font-weight:bold;">SELECT</span>
   <span style="color: #333;">text</span> <span >~*</span> <span style="color: blue;">'\w+'</span></pre>
+---
+<pre style="color: black; background-color: white;"><span style="font-weight:bold;">CREATE</span> <span style="font-weight:bold;">PROCEDURE</span> <span style="color: purple;">`foo`</span>() <span style="font-weight:bold;">BEGIN</span>
+  <span style="color: #333;">bar</span> <span >:</span> <span style="color: #333;">LOOP</span>
+    <span style="color: #aaa;">-- Nothing</span>
+  <span style="font-weight:bold;">END</span> <span style="color: #333;">LOOP</span> <span style="color: #333;">bar</span><span >;</span>
+<span style="font-weight:bold;">END</span></pre>

--- a/tests/format.txt
+++ b/tests/format.txt
@@ -1212,3 +1212,9 @@ SELECT
 ---
 SELECT
   text ~* '\w+'
+---
+CREATE PROCEDURE `foo`() BEGIN
+  bar : LOOP
+    -- Nothing
+  END LOOP bar;
+END

--- a/tests/highlight.html
+++ b/tests/highlight.html
@@ -431,3 +431,7 @@ JOIN</span> <span style="color: #333;">c</span> <span style="font-weight:bold;">
 <pre style="color: black; background-color: white;"><span style="font-weight:bold;">SELECT</span> <span style="color: #333;">vector1</span> <span >&lt;</span><span >#</span><span >&gt;</span> <span style="color: #333;">vector2</span></pre>
 ---
 <pre style="color: black; background-color: white;"><span style="font-weight:bold;">SELECT</span> <span style="color: #333;">text</span> <span >~*</span> <span style="color: blue;">'\w+'</span></pre>
+---
+<pre style="color: black; background-color: white;"><span style="font-weight:bold;">CREATE</span> <span style="font-weight:bold;">PROCEDURE</span> <span style="color: purple;">`foo`</span>() <span style="font-weight:bold;">BEGIN</span> <span style="color: #333;">bar</span><span >:</span><span style="color: #333;">LOOP</span>
+  <span style="color: #aaa;">-- Nothing</span>
+<span style="font-weight:bold;">END</span> <span style="color: #333;">LOOP</span> <span style="color: #333;">bar</span><span >;</span> <span style="font-weight:bold;">END</span></pre>

--- a/tests/sql.sql
+++ b/tests/sql.sql
@@ -431,3 +431,7 @@ SELECT '{}'::json #> '{}'
 SELECT vector1 <#> vector2
 ---
 SELECT text ~* '\w+'
+---
+CREATE PROCEDURE `foo`() BEGIN bar:LOOP
+  -- Nothing
+END LOOP bar; END


### PR DESCRIPTION
## Bug

`SqlFormatter::format()` crashes with `ValueError: str_repeat(): Argument #2 ($times) must be greater than or equal to 0` on MySQL stored procedures using label syntax with no space after the colon:

```php
use Doctrine\SqlFormatter\NullHighlighter;
use Doctrine\SqlFormatter\SqlFormatter;

$stmt = 'CREATE PROCEDURE `foo`()
BEGIN
  bar:LOOP
    -- Nothing
  END LOOP bar;
END';

(new SqlFormatter(new NullHighlighter()))->format($stmt);
// ValueError in src/SqlFormatter.php:94
```

`bar: LOOP` (with a space) does not crash; the trigger is specifically `:` glued to `LOOP`.

## Root cause

The tokenizer lexes `:` as a bind-variable prefix, so `bar:LOOP` tokenizes as `WORD('bar')` + `VARIABLE(':LOOP')`. The `LOOP` keyword is swallowed and the indent-opener branch in `SqlFormatter::format()` never fires, while `END LOOP` and the final `END` each still decrement the indentation level. It reaches `-1` and `str_repeat($tab, $indentLevel)` throws.

## Fix

A colon immediately preceded by a word character is never a bind-variable prefix in any supported dialect — it is a label separator (MySQL/Oracle `label:LOOP`). This PR guards the `:` alternative of the `VARIABLE` pattern with a negative lookbehind:

```diff
-Token::TOKEN_TYPE_VARIABLE => '[@:](?:...)',
+Token::TOKEN_TYPE_VARIABLE => '(?:@|(?<!\w):)(?:...)',
```

`@` keeps its old unconditional behavior; only `:` gets the guard.

## Impact on existing behavior

- Zero changes to existing fixtures: all pre-existing sections of `tests/sql.sql` render byte-identically across all five expected-output files (only the new regression section is appended).
- Bind variables are unaffected: `:param`, `@var`, `WHERE x = :id` still tokenize as `TOKEN_TYPE_VARIABLE` (covered by a new tokenizer test). PostgreSQL casts (`1::text`, `'{}'::json`) are unaffected — in `::` the second `:` is preceded by `:`, not a word character.
- One intentional re-tokenization: a `:` glued to a preceding identifier or number (e.g. the `:5` in a PostgreSQL array slice `arr[1:5]`) was `VARIABLE` and becomes `BOUNDARY` + `WORD`. No fixture covers it and rendered output is equivalent; such a colon is never a placeholder in any supported dialect.

## Tests

- New tokenizer cases: `bar:loop` → `WORD` + `BOUNDARY` + `WORD`, and `:param` → `VARIABLE`.
- New format regression fixture (the procedure above), expected outputs regenerated with `bin/regenerate-expected-output`.
- `phpunit`, `phpstan analyse` and `phpcs` all pass.

Relates to #118 (formatter must never fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)